### PR TITLE
ELPA compatibility minor edits

### DIFF
--- a/jinja2-mode.el
+++ b/jinja2-mode.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2011 Florian Mounier aka paradoxxxzero
 
 ;; Author: Florian Mounier aka paradoxxxzero
+;; Version: 0.1
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -316,3 +317,5 @@
 (add-to-list 'auto-mode-alist '("\\.jinja2\\'" . jinja2-mode))
 
 (provide 'jinja2-mode)
+
+;;; jinja2-mode.el ends here


### PR DESCRIPTION
In light of https://github.com/paradoxxxzero/jinja2-mode/pull/4 I've added ";;; jinja2-mode.el ends here" line at the end and "Version:" header, because when you try to install the package using `package-install`file, it gives the following errors:

```
package-buffer-info: Search failed: ";;; jinja2-mode.el ends here"

Debugger entered--Lisp error: (error "Package lacks a \"Version\" or \"Package-Version\" header")
  signal(error ("Package lacks a \"Version\" or \"Package-Version\" header"))
  error("Package lacks a \"Version\" or \"Package-Version\" header")
  package-buffer-info()
  package-install-file("~/jinja2-mode/jinja2-mode.el")
  call-interactively(package-install-file record nil)
  command-execute(package-install-file record)
  execute-extended-command(nil "package-install-file")
  call-interactively(execute-extended-command nil nil)
```
