### PR TITLE
Derive from html-mode instead of sgml-mode

### DIFF
--- a/jinja2-mode.el
+++ b/jinja2-mode.el
@@ -293,7 +293,7 @@
 
 
 ;;;###autoload
-(define-derived-mode jinja2-mode sgml-mode  "Jinja2"
+(define-derived-mode jinja2-mode html-mode  "Jinja2"
   "Major mode for editing jinja2 files"
   :group 'jinja2
   ;; Disabling this because of this emacs bug: 


### PR DESCRIPTION
This makes indentation and closing of empty HTML work correctly.
