### PR TITLE
add j2 extension

### DIFF
--- a/jinja2-mode.el
+++ b/jinja2-mode.el
@@ -322,6 +322,8 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jinja2\\'" . jinja2-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.j2\\'" . jinja2-mode))
 
 (provide 'jinja2-mode)
 


### PR DESCRIPTION
j2 is a commonly used extensions for jinja2
