### PR TITLE
Indent on save only when enabled, default disabled

### DIFF
--- a/jinja2-mode.el
+++ b/jinja2-mode.el
@@ -230,6 +230,8 @@
 (defvar jinja2-font-lock-keywords
   jinja2-font-lock-keywords-1)
 
+(defvar jinja2-enable-indent-on-save nil)
+
 (defun sgml-indent-line-num ()
   "Indent the current line as SGML."
   (let* ((savep (point))
@@ -323,9 +325,11 @@
 (define-key jinja2-mode-map (kbd "C-c t") 'jinja2-insert-tag)
 (define-key jinja2-mode-map (kbd "C-c v") 'jinja2-insert-var)
 (define-key jinja2-mode-map (kbd "C-c #") 'jinja2-insert-comment)
-(add-hook 'jinja2-mode-hook
-          (lambda ()
-            (add-hook 'after-save-hook 'jinja2-indent-buffer nil 'make-it-local)))
+
+(when jinja2-enable-indent-on-save
+  (add-hook 'jinja2-mode-hook
+    (lambda ()
+      (add-hook 'after-save-hook 'jinja2-indent-buffer nil 'make-it-local))))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.jinja2\\'" . jinja2-mode))


### PR DESCRIPTION
This behavior is annoying when editing a project that was not developed by emacs. Since this is most projects I suggest having this functionality disabled by default, and easy to toggle from config files.

Fixes  #16.