### PR TITLE
Add lexical binding token, fix for `jinja2-close-tag`.

### DIFF
--- a/jinja2-mode.el
+++ b/jinja2-mode.el
@@ -1,4 +1,4 @@
-;;; jinja2-mode.el --- A major mode for jinja2
+;;; jinja2-mode.el --- A major mode for jinja2 -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2011-2022 Florian Mounier aka paradoxxxzero
 
@@ -302,7 +302,7 @@
 (define-derived-mode jinja2-mode html-mode  "Jinja2"
   "Major mode for editing jinja2 files"
   :group 'jinja2
-  ;; Disabling this because of this emacs bug: 
+  ;; Disabling this because of this emacs bug:
   ;;  http://lists.gnu.org/archive/html/bug-gnu-emacs/2002-09/msg00041.html
   ;; (modify-syntax-entry ?\'  "\"" sgml-mode-syntax-table)
   (set (make-local-variable 'comment-start) "{#")

--- a/jinja2-mode.el
+++ b/jinja2-mode.el
@@ -126,7 +126,7 @@
              (format "{%% end%s%s %%}"
                      (car open-tag)(nth 1 open-tag))
            (format "{%% end%s %%}"
-                   (match-string 2))))
+                   (car open-tag))))
       (error "Nothing to close")))
   (save-excursion (jinja2-indent-line)))
 


### PR DESCRIPTION
First step in converting jinja2 mode to modern Emacs. Adds the `-*- lexical-binding: t -*-` comment to declare lexical binding. This is safe as existing code does not use dynamic binding (except for **defvar** and **defcustom**, of course.)

Also makes small correction to `jinja2-close-tag` recommended by Claude.